### PR TITLE
Fix birdc query for RoutesFiltered

### DIFF
--- a/bird/bird.go
+++ b/bird/bird.go
@@ -200,7 +200,7 @@ func RoutesProtoCount(protocol string) (Parsed, bool) {
 }
 
 func RoutesFiltered(protocol string) (Parsed, bool) {
-	cmd := routeQueryForChannel("route all filtered " + protocol)
+	cmd := routeQueryForChannel("route all filtered protocol " + protocol)
 	return RunAndParse(cmd, parseRoutes)
 }
 


### PR DESCRIPTION
There is a `protocol` missing. The query should read `show route all filtered protocol <protocol>` or `show route filtered protocol <protocol> all`
When you submit the query to birdc it responds with `IP address expected`. This is fixed now.